### PR TITLE
Reset iOS/macOS EventStore on error

### DIFF
--- a/src/Plugin.Maui.CalendarStore/CalendarStore.macios.cs
+++ b/src/Plugin.Maui.CalendarStore/CalendarStore.macios.cs
@@ -53,6 +53,8 @@ partial class CalendarStoreImplementation : ICalendarStore
 
 		if (!saveResult || error is not null)
 		{
+			EventStore.Reset();
+
 			if (error is not null)
 			{
 				throw new CalendarStoreException($"Error occurred while saving calendar: " +
@@ -173,6 +175,8 @@ partial class CalendarStoreImplementation : ICalendarStore
 
 		if (!saveResult || error is not null)
 		{
+			EventStore.Reset();
+
 			if (error is not null)
 			{
 				throw new CalendarStoreException($"Error occurred while saving event: " +
@@ -212,6 +216,8 @@ partial class CalendarStoreImplementation : ICalendarStore
 
 		if (!removeResult || error is not null)
 		{
+			EventStore.Reset();
+
 			if (error is not null)
 			{
 				throw new CalendarStoreException($"Error occurred while removing event: " +


### PR DESCRIPTION
Reset the EventStore when something fails. If we don't we might see events/calendars in there with actions that have not been saved and thus are not the truth.