### PR TITLE
Return CalendarItemIdentifier for iOS/macOS when creating an event

### DIFF
--- a/samples/Plugin.Maui.CalendarStore.Sample/AddEventsPage.xaml.cs
+++ b/samples/Plugin.Maui.CalendarStore.Sample/AddEventsPage.xaml.cs
@@ -95,27 +95,32 @@ public partial class AddEventsPage : ContentPage
 			var startEndDateTime = new DateTime(EventEndDate.Year, EventEndDate.Month,
 				EventEndDate.Day, EventEndTime.Hours, EventEndTime.Minutes, EventEndTime.Seconds);
 
+			string savedEventId = string.Empty;
+
 			// Check if we're updating an event
 			if (eventToUpdate is not null)
 			{
 				await calendarStore.UpdateEvent(eventToUpdate.Id, EventTitle, EventDescription,
 					EventLocation, startDateTime, startEndDateTime, EventIsAllDay);
+
+				await DisplayAlert("Event saved", $"The event has been successfully updated!", "OK");
 			}
 			else
 			{
+				// We could also not use this overload and just provide EventIsAllDay as a parameter
 				if (EventIsAllDay)
 				{
-					await calendarStore.CreateAllDayEvent(SelectedCalendar.Id, EventTitle,
+					savedEventId = await calendarStore.CreateAllDayEvent(SelectedCalendar.Id, EventTitle,
 						EventDescription, EventLocation, startDateTime, startEndDateTime);
 				}
 				else
 				{
-					await calendarStore.CreateEvent(SelectedCalendar.Id, EventTitle,
+					savedEventId = await calendarStore.CreateEvent(SelectedCalendar.Id, EventTitle,
 						EventDescription, EventLocation, startDateTime, startEndDateTime);
 				}
-			}
 
-			await DisplayAlert("Event saved", "The event has been successfully saved!", "OK");
+				await DisplayAlert("Event saved", $"The event has been successfully saved with ID: {savedEventId}!", "OK");
+			}
 
 			await Shell.Current.Navigation.PopAsync();
 		}

--- a/src/Plugin.Maui.CalendarStore/CalendarStore.macios.cs
+++ b/src/Plugin.Maui.CalendarStore/CalendarStore.macios.cs
@@ -218,7 +218,7 @@ partial class CalendarStoreImplementation : ICalendarStore
 			throw new CalendarStoreException("Saving the event was unsuccessful.");
 		}
 
-		return eventToSave.EventIdentifier;
+		return eventToSave.CalendarItemIdentifier;
 	}
 
 	/// <inheritdoc/>


### PR DESCRIPTION
When creating an event, for iOS and macOS the `EKEvent. EventIdentifier` was wrongfully returned while it should have been the `EKEvent. CalendarItemIdentifier`. This fixes that!

Fixes #37