### PR TITLE
Fix missing email address on iOS

### DIFF
--- a/src/Plugin.Maui.CalendarStore/CalendarEventAttendee.shared.cs
+++ b/src/Plugin.Maui.CalendarStore/CalendarEventAttendee.shared.cs
@@ -3,7 +3,6 @@ namespace Plugin.Maui.CalendarStore;
 /// <summary>
 /// Represents an attendee that is part of a calendar event from the device's calendar store.
 /// </summary>
-/// <remarks>On iOS <see cref="Email"/> is equal to <see cref="Name"/> as there is no obvious way to retrieve the email data from an attendee.</remarks>
 public class CalendarEventAttendee
 {
 	/// <summary>

--- a/src/Plugin.Maui.CalendarStore/CalendarStore.macios.cs
+++ b/src/Plugin.Maui.CalendarStore/CalendarStore.macios.cs
@@ -1,5 +1,4 @@
-﻿using System.Diagnostics;
-using EventKit;
+﻿using EventKit;
 using Foundation;
 using Microsoft.Maui.Graphics.Platform;
 using UIKit;
@@ -420,12 +419,15 @@ partial class CalendarStoreImplementation : ICalendarStore
 		{
 			// There is no obvious way to get the attendees email address on iOS?
 			yield return new(attendee.Name ?? string.Empty,
-				ToEmailAddress(attendee.Url) ?? string.Empty);
+				ToEmailAddress(attendee.Url));
 		}
 	}
 	
-	static string ToEmailAddress(NSUrl url)
+	static string ToEmailAddress(NSUrl? url)
 	{
+		if (url is null)
+			return string.Empty;
+		
 		var urlString = url.AbsoluteString;
 		if (string.IsNullOrEmpty(urlString))
 			return string.Empty;

--- a/src/Plugin.Maui.CalendarStore/CalendarStore.macios.cs
+++ b/src/Plugin.Maui.CalendarStore/CalendarStore.macios.cs
@@ -1,4 +1,5 @@
-﻿using EventKit;
+﻿using System.Diagnostics;
+using EventKit;
 using Foundation;
 using Microsoft.Maui.Graphics.Platform;
 using UIKit;
@@ -419,10 +420,22 @@ partial class CalendarStoreImplementation : ICalendarStore
 		{
 			// There is no obvious way to get the attendees email address on iOS?
 			yield return new(attendee.Name ?? string.Empty,
-				attendee.Name ?? string.Empty);
+				ToEmailAddress(attendee.Url) ?? string.Empty);
 		}
 	}
+	
+	static string ToEmailAddress(NSUrl url)
+	{
+		var urlString = url.AbsoluteString;
+		if (string.IsNullOrEmpty(urlString))
+			return string.Empty;
 
+		if (Uri.TryCreate(urlString, UriKind.Absolute, out var uri) && uri!.Scheme == Uri.UriSchemeMailto)
+			return $"{uri.UserInfo}@{uri.DnsSafeHost}";
+
+		return string.Empty;
+	}
+	
 	static DateTimeOffset ToDateTimeOffsetWithTimezone(NSDate platformDate, NSTimeZone? timezone)
 	{
 		var timezoneToApply = NSTimeZone.DefaultTimeZone;


### PR DESCRIPTION
Added ability to parse EKPaticipant.Url from a mailto url like "mailto:emailaddress@domain.com" into the email field.