### PR TITLE
Fix CI: pin .NET 9 SDK and install MAUI workload

### DIFF
--- a/.github/workflows/ci-sample.yml
+++ b/.github/workflows/ci-sample.yml
@@ -14,7 +14,15 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 9.0.x
+
+    - name: Install MAUI workload
+      run: dotnet workload install maui
 
     - name: Build
       run: dotnet build samples/Plugin.Maui.CalendarStore.Sample/Plugin.Maui.CalendarStore.Sample.csproj -c Release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,15 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 9.0.x
+
+    - name: Install MAUI workload
+      run: dotnet workload install maui
 
     - name: Build
       run: dotnet build src/Plugin.Maui.CalendarStore/Plugin.Maui.CalendarStore.csproj -c Release

--- a/.github/workflows/release-nuget.yml
+++ b/.github/workflows/release-nuget.yml
@@ -11,11 +11,19 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Verify commit exists in origin/main
         run: |
           git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*
           git branch --remote --contains | grep origin/main
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 9.0.x
+
+      - name: Install MAUI workload
+        run: dotnet workload install maui
 
       - name: Get version information from tag
         id: get_version


### PR DESCRIPTION
## Problem

The `windows-latest` GitHub Actions runner now ships with .NET SDK 10.0.102, which does not include the .NET 9 MAUI workloads. This causes all CI builds to fail with:

```
error NETSDK1147: To build this project, the following workloads must be installed: android
```

## Fix

All three workflow files (`ci.yml`, `ci-sample.yml`, `release-nuget.yml`) are updated to:

1. **Pin .NET SDK to 9.0.x** via `actions/setup-dotnet@v4`
2. **Install the MAUI workload** explicitly with `dotnet workload install maui`
3. **Bump `actions/checkout`** from v3 to v4