### PR TITLE
Fix stale event data on iOS and Android

### DIFF
--- a/src/Plugin.Maui.CalendarStore.sln
+++ b/src/Plugin.Maui.CalendarStore.sln
@@ -5,16 +5,42 @@ VisualStudioVersion = 25.0.1704.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Plugin.Maui.CalendarStore", "Plugin.Maui.CalendarStore\Plugin.Maui.CalendarStore.csproj", "{2012F564-B8C7-4CEB-8495-1BCB1B0EB638}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Plugin.Maui.CalendarStore.Tests", "..\tests\Plugin.Maui.CalendarStore.Tests\Plugin.Maui.CalendarStore.Tests.csproj", "{588CB7C0-D55A-4C07-86AC-D8028A4864A4}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{2012F564-B8C7-4CEB-8495-1BCB1B0EB638}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{2012F564-B8C7-4CEB-8495-1BCB1B0EB638}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2012F564-B8C7-4CEB-8495-1BCB1B0EB638}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{2012F564-B8C7-4CEB-8495-1BCB1B0EB638}.Debug|x64.Build.0 = Debug|Any CPU
+		{2012F564-B8C7-4CEB-8495-1BCB1B0EB638}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{2012F564-B8C7-4CEB-8495-1BCB1B0EB638}.Debug|x86.Build.0 = Debug|Any CPU
 		{2012F564-B8C7-4CEB-8495-1BCB1B0EB638}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2012F564-B8C7-4CEB-8495-1BCB1B0EB638}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2012F564-B8C7-4CEB-8495-1BCB1B0EB638}.Release|x64.ActiveCfg = Release|Any CPU
+		{2012F564-B8C7-4CEB-8495-1BCB1B0EB638}.Release|x64.Build.0 = Release|Any CPU
+		{2012F564-B8C7-4CEB-8495-1BCB1B0EB638}.Release|x86.ActiveCfg = Release|Any CPU
+		{2012F564-B8C7-4CEB-8495-1BCB1B0EB638}.Release|x86.Build.0 = Release|Any CPU
+		{588CB7C0-D55A-4C07-86AC-D8028A4864A4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{588CB7C0-D55A-4C07-86AC-D8028A4864A4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{588CB7C0-D55A-4C07-86AC-D8028A4864A4}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{588CB7C0-D55A-4C07-86AC-D8028A4864A4}.Debug|x64.Build.0 = Debug|Any CPU
+		{588CB7C0-D55A-4C07-86AC-D8028A4864A4}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{588CB7C0-D55A-4C07-86AC-D8028A4864A4}.Debug|x86.Build.0 = Debug|Any CPU
+		{588CB7C0-D55A-4C07-86AC-D8028A4864A4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{588CB7C0-D55A-4C07-86AC-D8028A4864A4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{588CB7C0-D55A-4C07-86AC-D8028A4864A4}.Release|x64.ActiveCfg = Release|Any CPU
+		{588CB7C0-D55A-4C07-86AC-D8028A4864A4}.Release|x64.Build.0 = Release|Any CPU
+		{588CB7C0-D55A-4C07-86AC-D8028A4864A4}.Release|x86.ActiveCfg = Release|Any CPU
+		{588CB7C0-D55A-4C07-86AC-D8028A4864A4}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Plugin.Maui.CalendarStore/CalendarStore.android.cs
+++ b/src/Plugin.Maui.CalendarStore/CalendarStore.android.cs
@@ -233,8 +233,8 @@ partial class CalendarStoreImplementation : ICalendarStore
 		var sDate = startDate ?? DateTimeOffset.Now.Add(defaultStartTimeFromNow);
 		var eDate = endDate ?? sDate.Add(defaultEndTimeFromStartTime);
 
-		var startMillis = sDate.ToUnixTimeMilliseconds();
-		var endMillis = eDate.ToUnixTimeMilliseconds();
+		var startMillis = CalendarStore.ToFilterTimestampMillis(sDate);
+		var endMillis = CalendarStore.ToFilterTimestampMillis(eDate);
 
 		// Build the Instances URI with date range encoded in the path.
 		// This is the Android-recommended way to query events by date range,
@@ -791,15 +791,22 @@ partial class CalendarStoreImplementation : ICalendarStore
 
 	IEnumerable<CalendarEvent> ToEventsFromInstances(ICursor cur, List<string> projection)
 	{
+		// Cache attendees and reminders by EventId to avoid redundant queries
+		// for recurring events (which share the same EventId across occurrences).
+		var attendeesCache = new Dictionary<string, List<CalendarEventAttendee>>();
+		var remindersCache = new Dictionary<long, List<Reminder>>();
+
 		while (cur.MoveToNext())
 		{
-			yield return ToEventFromInstance(cur, projection);
+			yield return ToEventFromInstance(cur, projection, attendeesCache, remindersCache);
 		}
 
 		SafeCloseCursor(cur);
 	}
 
-	CalendarEvent ToEventFromInstance(ICursor cursor, List<string> projection)
+	CalendarEvent ToEventFromInstance(ICursor cursor, List<string> projection,
+		Dictionary<string, List<CalendarEventAttendee>> attendeesCache,
+		Dictionary<long, List<Reminder>> remindersCache)
 	{
 		var timezone = cursor.GetString(projection.IndexOf(CalendarContract.Events.InterfaceConsts.EventTimezone));
 		var allDay = cursor.GetInt(projection.IndexOf(CalendarContract.Events.InterfaceConsts.AllDay)) != 0;
@@ -843,9 +850,31 @@ partial class CalendarStoreImplementation : ICalendarStore
 			StartDate = SafeConvertTime(start, timezone),
 			EndDate = SafeConvertTime(end, timezone),
 			EventColor = GetEventColor(cursor, projection),
-			Attendees = GetAttendees(eventIdString).ToList(),
-			Reminders = GetAllEventReminders(eventId),
+			Attendees = GetCachedAttendees(eventIdString, attendeesCache),
+			Reminders = GetCachedReminders(eventId, remindersCache),
 		};
+	}
+
+	List<CalendarEventAttendee> GetCachedAttendees(string eventId,
+		Dictionary<string, List<CalendarEventAttendee>> cache)
+	{
+		if (!cache.TryGetValue(eventId, out var attendees))
+		{
+			attendees = GetAttendees(eventId).ToList();
+			cache[eventId] = attendees;
+		}
+		return attendees;
+	}
+
+	List<Reminder> GetCachedReminders(long eventId,
+		Dictionary<long, List<Reminder>> cache)
+	{
+		if (!cache.TryGetValue(eventId, out var reminders))
+		{
+			reminders = GetAllEventReminders(eventId);
+			cache[eventId] = reminders;
+		}
+		return reminders;
 	}
 
 	static IEnumerable<CalendarEventAttendee> ToAttendees(ICursor cur, List<string> projection)

--- a/src/Plugin.Maui.CalendarStore/CalendarStore.android.cs
+++ b/src/Plugin.Maui.CalendarStore/CalendarStore.android.cs
@@ -246,10 +246,10 @@ partial class CalendarStoreImplementation : ICalendarStore
 		var instancesUri = builder.Build()
 			?? throw new CalendarStoreException("Could not build Instances query URI.");
 
-		string? selection = null;
+		var selection = $"{CalendarContract.Events.InterfaceConsts.Deleted} != 1";
 		if (!string.IsNullOrEmpty(calendarId))
 		{
-			selection = $"{CalendarContract.Events.InterfaceConsts.CalendarId} = {calendarId}";
+			selection += $" AND {CalendarContract.Events.InterfaceConsts.CalendarId} = {calendarId}";
 		}
 
 		var sortOrder = $"{CalendarContract.Instances.Begin} ASC";

--- a/src/Plugin.Maui.CalendarStore/CalendarStore.android.cs
+++ b/src/Plugin.Maui.CalendarStore/CalendarStore.android.cs
@@ -42,6 +42,18 @@ partial class CalendarStoreImplementation : ICalendarStore
 				CalendarContract.Events.InterfaceConsts.EventColor,
 			];
 
+	readonly List<string> instancesColumns = [
+			CalendarContract.Instances.EventId,
+				CalendarContract.Events.InterfaceConsts.CalendarId,
+				CalendarContract.Events.InterfaceConsts.Title,
+				CalendarContract.Events.InterfaceConsts.Description,
+				CalendarContract.Events.InterfaceConsts.EventLocation,
+				CalendarContract.Events.InterfaceConsts.AllDay,
+				CalendarContract.Instances.Begin,
+				CalendarContract.Instances.End,
+				CalendarContract.Events.InterfaceConsts.EventTimezone,
+			];
+
 	readonly List<string> attendeesColumns =
 		[
 			CalendarContract.Attendees.InterfaceConsts.EventId,
@@ -221,23 +233,29 @@ partial class CalendarStoreImplementation : ICalendarStore
 		var sDate = startDate ?? DateTimeOffset.Now.Add(defaultStartTimeFromNow);
 		var eDate = endDate ?? sDate.Add(defaultEndTimeFromStartTime);
 
-		var calendarSpecificEvent =
-			$"{CalendarContract.Events.InterfaceConsts.Dtend} >= " +
-			$"{sDate.AddMilliseconds(sDate.Offset.TotalMilliseconds).ToUnixTimeMilliseconds()} AND " +
-			$"{CalendarContract.Events.InterfaceConsts.Dtstart} <= " +
-			$"{eDate.AddMilliseconds(sDate.Offset.TotalMilliseconds).ToUnixTimeMilliseconds()} AND " +
-			$"{CalendarContract.Events.InterfaceConsts.Deleted} != 1 ";
+		var startMillis = sDate.ToUnixTimeMilliseconds();
+		var endMillis = eDate.ToUnixTimeMilliseconds();
 
+		// Build the Instances URI with date range encoded in the path.
+		// This is the Android-recommended way to query events by date range,
+		// as the Instances table expands recurring events and reflects
+		// externally synced changes (fixes stale data from issue #51).
+		var builder = CalendarContract.Instances.ContentUri!.BuildUpon()!;
+		ContentUris.AppendId(builder, startMillis);
+		ContentUris.AppendId(builder, endMillis);
+		var instancesUri = builder.Build()
+			?? throw new CalendarStoreException("Could not build Instances query URI.");
+
+		string? selection = null;
 		if (!string.IsNullOrEmpty(calendarId))
 		{
-			calendarSpecificEvent += $" AND {CalendarContract.Events.InterfaceConsts.CalendarId}" +
-				$" = {calendarId}";
+			selection = $"{CalendarContract.Events.InterfaceConsts.CalendarId} = {calendarId}";
 		}
 
-		var sortOrder = $"{CalendarContract.Events.InterfaceConsts.Dtstart} ASC";
+		var sortOrder = $"{CalendarContract.Instances.Begin} ASC";
 
-		using var cursor = platformContentResolver.Query(eventsTableUri,
-			eventsColumns.ToArray(), calendarSpecificEvent, null, sortOrder)
+		using var cursor = platformContentResolver.Query(instancesUri,
+			instancesColumns.ToArray(), selection, null, sortOrder)
 			?? throw new CalendarStoreException("Error while querying events");
 
 		// Confirm the calendar exists if no events were found
@@ -246,7 +264,7 @@ partial class CalendarStoreImplementation : ICalendarStore
 			await GetCalendar(calendarId).ConfigureAwait(false);
 		}
 
-		return ToEvents(cursor, eventsColumns).ToList();
+		return ToEventsFromInstances(cursor, instancesColumns).ToList();
 	}
 
 	/// <inheritdoc/>
@@ -720,7 +738,7 @@ partial class CalendarStoreImplementation : ICalendarStore
 		var start = DateTimeOffset.FromUnixTimeMilliseconds(cursor.GetLong(projection.IndexOf(CalendarContract.Events.InterfaceConsts.Dtstart)));
 		var end = DateTimeOffset.FromUnixTimeMilliseconds(cursor.GetLong(projection.IndexOf(CalendarContract.Events.InterfaceConsts.Dtend)));
 
-		DateTimeOffset SafeConvertTime(DateTimeOffset time, string tz)
+		DateTimeOffset SafeConvertTime(DateTimeOffset time, string? tz)
 		{
 			try
 			{
@@ -745,8 +763,8 @@ partial class CalendarStoreImplementation : ICalendarStore
 			Location = cursor.GetString(projection.IndexOf(
 				CalendarContract.Events.InterfaceConsts.EventLocation)) ?? string.Empty,
 			IsAllDay = allDay,
-			StartDate = timezone is null ? start : TimeZoneInfo.ConvertTimeBySystemTimeZoneId(start, timezone),
-			EndDate = timezone is null ? end : TimeZoneInfo.ConvertTimeBySystemTimeZoneId(end, timezone),
+			StartDate = SafeConvertTime(start, timezone),
+			EndDate = SafeConvertTime(end, timezone),
 			EventColor = GetEventColor(cursor, projection),
 			Attendees = GetAttendees(cursor.GetString(projection.IndexOf(
 				CalendarContract.Events.InterfaceConsts.Id)) ?? string.Empty).ToList(),
@@ -769,6 +787,65 @@ partial class CalendarStoreImplementation : ICalendarStore
 		}
 
 		return GetDisplayColorFromColor(new Android.Graphics.Color(eventColorInt)).AsColor();
+	}
+
+	IEnumerable<CalendarEvent> ToEventsFromInstances(ICursor cur, List<string> projection)
+	{
+		while (cur.MoveToNext())
+		{
+			yield return ToEventFromInstance(cur, projection);
+		}
+
+		SafeCloseCursor(cur);
+	}
+
+	CalendarEvent ToEventFromInstance(ICursor cursor, List<string> projection)
+	{
+		var timezone = cursor.GetString(projection.IndexOf(CalendarContract.Events.InterfaceConsts.EventTimezone));
+		var allDay = cursor.GetInt(projection.IndexOf(CalendarContract.Events.InterfaceConsts.AllDay)) != 0;
+
+		// Use Instances.Begin/End which reflect the actual occurrence times
+		// (including recurring event expansions and externally synced changes)
+		var start = DateTimeOffset.FromUnixTimeMilliseconds(cursor.GetLong(
+			projection.IndexOf(CalendarContract.Instances.Begin)));
+		var end = DateTimeOffset.FromUnixTimeMilliseconds(cursor.GetLong(
+			projection.IndexOf(CalendarContract.Instances.End)));
+
+		var eventIdString = cursor.GetString(projection.IndexOf(
+			CalendarContract.Instances.EventId)) ?? string.Empty;
+
+		if (!long.TryParse(eventIdString, out var eventId))
+		{
+			throw new CalendarStoreException($"Invalid Event ID: {eventIdString}");
+		}
+
+		DateTimeOffset SafeConvertTime(DateTimeOffset time, string? tz)
+		{
+			try
+			{
+				return tz is null ? time : TimeZoneInfo.ConvertTimeBySystemTimeZoneId(time, tz);
+			}
+			catch (TimeZoneNotFoundException)
+			{
+				return time;
+			}
+		}
+
+		return new(eventIdString,
+			cursor.GetString(projection.IndexOf(CalendarContract.Events.InterfaceConsts.CalendarId)) ?? string.Empty,
+			cursor.GetString(projection.IndexOf(CalendarContract.Events.InterfaceConsts.Title)) ?? string.Empty)
+		{
+			Description = cursor.GetString(projection.IndexOf(
+				CalendarContract.Events.InterfaceConsts.Description)) ?? string.Empty,
+			Location = cursor.GetString(projection.IndexOf(
+				CalendarContract.Events.InterfaceConsts.EventLocation)) ?? string.Empty,
+			IsAllDay = allDay,
+			StartDate = SafeConvertTime(start, timezone),
+			EndDate = SafeConvertTime(end, timezone),
+			EventColor = GetEventColor(cursor, projection),
+			Attendees = GetAttendees(eventIdString).ToList(),
+			Reminders = GetAllEventReminders(eventId),
+		};
 	}
 
 	static IEnumerable<CalendarEventAttendee> ToAttendees(ICursor cur, List<string> projection)

--- a/src/Plugin.Maui.CalendarStore/CalendarStore.android.cs
+++ b/src/Plugin.Maui.CalendarStore/CalendarStore.android.cs
@@ -246,11 +246,10 @@ partial class CalendarStoreImplementation : ICalendarStore
 		var instancesUri = builder.Build()
 			?? throw new CalendarStoreException("Could not build Instances query URI.");
 
-		var selection = $"{CalendarContract.Events.InterfaceConsts.Deleted} != 1";
-		if (!string.IsNullOrEmpty(calendarId))
-		{
-			selection += $" AND {CalendarContract.Events.InterfaceConsts.CalendarId} = {calendarId}";
-		}
+		var selection = CalendarStore.BuildInstancesSelection(
+			CalendarContract.Events.InterfaceConsts.Deleted,
+			CalendarContract.Events.InterfaceConsts.CalendarId,
+			calendarId);
 
 		var sortOrder = $"{CalendarContract.Instances.Begin} ASC";
 
@@ -850,31 +849,11 @@ partial class CalendarStoreImplementation : ICalendarStore
 			StartDate = SafeConvertTime(start, timezone),
 			EndDate = SafeConvertTime(end, timezone),
 			EventColor = GetEventColor(cursor, projection),
-			Attendees = GetCachedAttendees(eventIdString, attendeesCache),
-			Reminders = GetCachedReminders(eventId, remindersCache),
+			Attendees = CalendarStore.GetOrAdd(attendeesCache, eventIdString,
+				id => GetAttendees(id).ToList()),
+			Reminders = CalendarStore.GetOrAdd(remindersCache, eventId,
+				id => GetAllEventReminders(id)),
 		};
-	}
-
-	List<CalendarEventAttendee> GetCachedAttendees(string eventId,
-		Dictionary<string, List<CalendarEventAttendee>> cache)
-	{
-		if (!cache.TryGetValue(eventId, out var attendees))
-		{
-			attendees = GetAttendees(eventId).ToList();
-			cache[eventId] = attendees;
-		}
-		return attendees;
-	}
-
-	List<Reminder> GetCachedReminders(long eventId,
-		Dictionary<long, List<Reminder>> cache)
-	{
-		if (!cache.TryGetValue(eventId, out var reminders))
-		{
-			reminders = GetAllEventReminders(eventId);
-			cache[eventId] = reminders;
-		}
-		return reminders;
 	}
 
 	static IEnumerable<CalendarEventAttendee> ToAttendees(ICursor cur, List<string> projection)

--- a/src/Plugin.Maui.CalendarStore/CalendarStore.macios.cs
+++ b/src/Plugin.Maui.CalendarStore/CalendarStore.macios.cs
@@ -18,6 +18,8 @@ partial class CalendarStoreImplementation : ICalendarStore
 	{
 		await Permissions.RequestAsync<FullAccessCalendar>();
 
+		EventStore.Reset();
+
 		var calendars = EventStore.GetCalendars(EKEntityType.Event);
 
 		return ToCalendars(calendars).ToList();
@@ -128,7 +130,9 @@ partial class CalendarStoreImplementation : ICalendarStore
 	{
 		await Permissions.RequestAsync<FullAccessCalendar>();
 
-		var startDateToConvert = startDate ?? DateTimeOffset.Now.Add(
+		EventStore.Reset();
+
+		var startDateToConvert= startDate ?? DateTimeOffset.Now.Add(
 			defaultStartTimeFromNow);
 
 		// NOTE: 4 years is the maximum period that a iOS calendar events can search
@@ -358,6 +362,8 @@ partial class CalendarStoreImplementation : ICalendarStore
 
 		await Permissions.RequestAsync<FullAccessCalendar>();
 
+		EventStore.Reset();
+
 		var calendars = EventStore.GetCalendars(EKEntityType.Event);
 
 		return calendars.FirstOrDefault(c => c.CalendarIdentifier == calendarId);
@@ -368,6 +374,8 @@ partial class CalendarStoreImplementation : ICalendarStore
 		ArgumentException.ThrowIfNullOrEmpty(eventId);
 
 		await Permissions.RequestAsync<FullAccessCalendar>();
+
+		EventStore.Reset();
 
 		if (EventStore.GetCalendarItem(eventId) is not EKEvent calendarEvent)
 		{

--- a/src/Plugin.Maui.CalendarStore/CalendarStore.macios.cs
+++ b/src/Plugin.Maui.CalendarStore/CalendarStore.macios.cs
@@ -362,8 +362,6 @@ partial class CalendarStoreImplementation : ICalendarStore
 
 		await Permissions.RequestAsync<FullAccessCalendar>();
 
-		EventStore.Reset();
-
 		var calendars = EventStore.GetCalendars(EKEntityType.Event);
 
 		return calendars.FirstOrDefault(c => c.CalendarIdentifier == calendarId);
@@ -374,8 +372,6 @@ partial class CalendarStoreImplementation : ICalendarStore
 		ArgumentException.ThrowIfNullOrEmpty(eventId);
 
 		await Permissions.RequestAsync<FullAccessCalendar>();
-
-		EventStore.Reset();
 
 		if (EventStore.GetCalendarItem(eventId) is not EKEvent calendarEvent)
 		{

--- a/src/Plugin.Maui.CalendarStore/CalendarStore.macios.cs
+++ b/src/Plugin.Maui.CalendarStore/CalendarStore.macios.cs
@@ -132,7 +132,7 @@ partial class CalendarStoreImplementation : ICalendarStore
 
 		EventStore.Reset();
 
-		var startDateToConvert= startDate ?? DateTimeOffset.Now.Add(
+		var startDateToConvert = startDate ?? DateTimeOffset.Now.Add(
 			defaultStartTimeFromNow);
 
 		// NOTE: 4 years is the maximum period that a iOS calendar events can search

--- a/src/Plugin.Maui.CalendarStore/EventQueryHelper.shared.cs
+++ b/src/Plugin.Maui.CalendarStore/EventQueryHelper.shared.cs
@@ -16,4 +16,38 @@ static partial class CalendarStore
 		// milliseconds regardless of the offset, so no additional adjustment is needed.
 		return date.ToUnixTimeMilliseconds();
 	}
+
+	/// <summary>
+	/// Builds the SQL selection clause for filtering events in an Instances query.
+	/// Always excludes soft-deleted events and optionally filters by calendar ID.
+	/// </summary>
+	/// <param name="deletedColumn">The column name for the deleted flag.</param>
+	/// <param name="calendarIdColumn">The column name for the calendar ID.</param>
+	/// <param name="calendarId">Optional calendar ID to filter by.</param>
+	/// <returns>A SQL selection string.</returns>
+	internal static string BuildInstancesSelection(string deletedColumn,
+		string calendarIdColumn, string? calendarId = null)
+	{
+		var selection = $"{deletedColumn} != 1";
+		if (!string.IsNullOrEmpty(calendarId))
+		{
+			selection += $" AND {calendarIdColumn} = {calendarId}";
+		}
+		return selection;
+	}
+
+	/// <summary>
+	/// Retrieves a value from a cache, populating it via a factory on cache miss.
+	/// Used to avoid redundant queries for recurring event occurrences.
+	/// </summary>
+	internal static TValue GetOrAdd<TKey, TValue>(Dictionary<TKey, TValue> cache,
+		TKey key, Func<TKey, TValue> factory) where TKey : notnull
+	{
+		if (!cache.TryGetValue(key, out var value))
+		{
+			value = factory(key);
+			cache[key] = value;
+		}
+		return value;
+	}
 }

--- a/src/Plugin.Maui.CalendarStore/EventQueryHelper.shared.cs
+++ b/src/Plugin.Maui.CalendarStore/EventQueryHelper.shared.cs
@@ -9,9 +9,8 @@ static partial class CalendarStore
 	/// Computes the UTC timestamp in milliseconds for use in date range filters.
 	/// </summary>
 	/// <param name="date">The date to compute the filter timestamp for.</param>
-	/// <param name="referenceOffset">Unused. Kept for source compatibility during transition.</param>
 	/// <returns>The UTC timestamp in milliseconds since Unix epoch.</returns>
-	internal static long ToFilterTimestampMillis(DateTimeOffset date, TimeSpan referenceOffset)
+	internal static long ToFilterTimestampMillis(DateTimeOffset date)
 	{
 		// DateTimeOffset.ToUnixTimeMilliseconds() already returns UTC-based epoch
 		// milliseconds regardless of the offset, so no additional adjustment is needed.

--- a/src/Plugin.Maui.CalendarStore/EventQueryHelper.shared.cs
+++ b/src/Plugin.Maui.CalendarStore/EventQueryHelper.shared.cs
@@ -1,0 +1,20 @@
+namespace Plugin.Maui.CalendarStore;
+
+/// <summary>
+/// Helper methods for constructing calendar event date range queries.
+/// </summary>
+static partial class CalendarStore
+{
+	/// <summary>
+	/// Computes the UTC timestamp in milliseconds for use in date range filters.
+	/// </summary>
+	/// <param name="date">The date to compute the filter timestamp for.</param>
+	/// <param name="referenceOffset">Unused. Kept for source compatibility during transition.</param>
+	/// <returns>The UTC timestamp in milliseconds since Unix epoch.</returns>
+	internal static long ToFilterTimestampMillis(DateTimeOffset date, TimeSpan referenceOffset)
+	{
+		// DateTimeOffset.ToUnixTimeMilliseconds() already returns UTC-based epoch
+		// milliseconds regardless of the offset, so no additional adjustment is needed.
+		return date.ToUnixTimeMilliseconds();
+	}
+}

--- a/src/Plugin.Maui.CalendarStore/ICalendarStore.shared.cs
+++ b/src/Plugin.Maui.CalendarStore/ICalendarStore.shared.cs
@@ -65,6 +65,12 @@ public interface ICalendarStore
 	/// <param name="startDate">The start date of the range to retrieve events for.</param>
 	/// <param name="endDate">The end date of the range to retrieve events for.</param>
 	/// <returns>A list of events from the calendars on the device.</returns>
+	/// <remarks>
+	/// Recurring events are expanded into individual occurrences within the specified date range.
+	/// This means multiple <see cref="CalendarEvent"/> objects may be returned with the same
+	/// <see cref="CalendarEvent.Id"/> but different <see cref="CalendarEvent.StartDate"/> and
+	/// <see cref="CalendarEvent.EndDate"/> values.
+	/// </remarks>
 	/// <exception cref="PermissionException">Thrown when the permission to access the calendar is not granted.</exception>
 	/// <exception cref="ArgumentException">Thrown when a calendar with the value specified in <paramref name="calendarId"/> could not be found.</exception>
 	Task<IEnumerable<CalendarEvent>> GetEvents(string? calendarId = null,

--- a/src/Plugin.Maui.CalendarStore/Plugin.Maui.CalendarStore.csproj
+++ b/src/Plugin.Maui.CalendarStore/Plugin.Maui.CalendarStore.csproj
@@ -82,4 +82,8 @@
 		<None Include="..\..\README.md" PackagePath="README.md" Pack="true" />
 	</ItemGroup>
 
+	<ItemGroup>
+		<InternalsVisibleTo Include="Plugin.Maui.CalendarStore.Tests" />
+	</ItemGroup>
+
 </Project>

--- a/tests/Plugin.Maui.CalendarStore.Tests/CalendarStoreFacadeTests.cs
+++ b/tests/Plugin.Maui.CalendarStore.Tests/CalendarStoreFacadeTests.cs
@@ -1,0 +1,165 @@
+using Plugin.Maui.CalendarStore;
+
+namespace Plugin.Maui.CalendarStore.Tests;
+
+/// <summary>
+/// Tests the static <see cref="CalendarStore"/> facade to ensure it properly
+/// delegates to the underlying <see cref="ICalendarStore"/> implementation
+/// and always returns fresh data on each call.
+/// </summary>
+public sealed class CalendarStoreFacadeTests : IDisposable
+{
+	public CalendarStoreFacadeTests()
+	{
+		CalendarStore.SetDefault(null);
+	}
+
+	public void Dispose()
+	{
+		CalendarStore.SetDefault(null);
+	}
+
+	[Fact]
+	public async Task GetEvents_DelegatesCallToImplementation()
+	{
+		var expectedEvent = CreateEvent("e1", "cal1", "Test Event");
+
+		var mock = new MockCalendarStore
+		{
+			OnGetEvents = (_, _, _) =>
+				Task.FromResult<IEnumerable<CalendarEvent>>(new[] { expectedEvent })
+		};
+
+		CalendarStore.SetDefault(mock);
+
+		var events = (await CalendarStore.Default.GetEvents()).ToList();
+
+		Assert.Single(events);
+		Assert.Equal("e1", events[0].Id);
+		Assert.Equal("Test Event", events[0].Title);
+	}
+
+	[Fact]
+	public async Task GetEvents_ReturnsUpdatedData_OnSubsequentCalls()
+	{
+		// Simulates the scenario from issue #51: events change externally
+		// and subsequent calls should reflect the new data.
+		int callCount = 0;
+		var mock = new MockCalendarStore
+		{
+			OnGetEvents = (_, _, _) =>
+			{
+				callCount++;
+				if (callCount == 1)
+				{
+					return Task.FromResult<IEnumerable<CalendarEvent>>(new[]
+					{
+						CreateEvent("e1", "cal1", "December Meeting",
+							startMonth: 12, endMonth: 12)
+					});
+				}
+
+				// Second call: event was moved to January externally
+				return Task.FromResult<IEnumerable<CalendarEvent>>(new[]
+				{
+					CreateEvent("e1", "cal1", "December Meeting",
+						startMonth: 1, endMonth: 1)
+				});
+			}
+		};
+
+		CalendarStore.SetDefault(mock);
+
+		var firstResult = (await CalendarStore.Default.GetEvents()).ToList();
+		Assert.Equal(12, firstResult[0].StartDate.Month);
+
+		var secondResult = (await CalendarStore.Default.GetEvents()).ToList();
+		Assert.Equal(1, secondResult[0].StartDate.Month);
+
+		Assert.Equal(2, callCount);
+	}
+
+	[Fact]
+	public async Task GetCalendars_DelegatesCallToImplementation()
+	{
+		var expectedCalendar = new Calendar("cal1", "Work", Colors.Blue, false);
+
+		var mock = new MockCalendarStore
+		{
+			OnGetCalendars = () =>
+				Task.FromResult<IEnumerable<Calendar>>(new[] { expectedCalendar })
+		};
+
+		CalendarStore.SetDefault(mock);
+
+		var calendars = (await CalendarStore.Default.GetCalendars()).ToList();
+
+		Assert.Single(calendars);
+		Assert.Equal("cal1", calendars[0].Id);
+		Assert.Equal("Work", calendars[0].Name);
+	}
+
+	[Fact]
+	public async Task GetEvent_DelegatesCallToImplementation()
+	{
+		var expectedEvent = CreateEvent("e1", "cal1", "Meeting");
+
+		var mock = new MockCalendarStore
+		{
+			OnGetEvent = (id) =>
+			{
+				Assert.Equal("e1", id);
+				return Task.FromResult(expectedEvent);
+			}
+		};
+
+		CalendarStore.SetDefault(mock);
+
+		var result = await CalendarStore.Default.GetEvent("e1");
+
+		Assert.Equal("Meeting", result.Title);
+	}
+
+	[Fact]
+	public async Task GetEvents_PassesThroughFilterParameters()
+	{
+		string? capturedCalendarId = null;
+		DateTimeOffset? capturedStart = null;
+		DateTimeOffset? capturedEnd = null;
+
+		var mock = new MockCalendarStore
+		{
+			OnGetEvents = (calId, start, end) =>
+			{
+				capturedCalendarId = calId;
+				capturedStart = start;
+				capturedEnd = end;
+				return Task.FromResult<IEnumerable<CalendarEvent>>(Array.Empty<CalendarEvent>());
+			}
+		};
+
+		CalendarStore.SetDefault(mock);
+
+		var start = new DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero);
+		var end = new DateTimeOffset(2025, 1, 31, 23, 59, 59, TimeSpan.Zero);
+
+		await CalendarStore.Default.GetEvents("my-calendar", start, end);
+
+		Assert.Equal("my-calendar", capturedCalendarId);
+		Assert.Equal(start, capturedStart);
+		Assert.Equal(end, capturedEnd);
+	}
+
+	/// <summary>
+	/// Helper to create a <see cref="CalendarEvent"/> with internal-set properties.
+	/// </summary>
+	static CalendarEvent CreateEvent(string id, string calendarId, string title,
+		int startMonth = 6, int endMonth = 6)
+	{
+		return new CalendarEvent(id, calendarId, title)
+		{
+			StartDate = new DateTimeOffset(2025, startMonth, 15, 10, 0, 0, TimeSpan.Zero),
+			EndDate = new DateTimeOffset(2025, endMonth, 15, 11, 0, 0, TimeSpan.Zero)
+		};
+	}
+}

--- a/tests/Plugin.Maui.CalendarStore.Tests/CalendarStoreFacadeTests.cs
+++ b/tests/Plugin.Maui.CalendarStore.Tests/CalendarStoreFacadeTests.cs
@@ -82,7 +82,7 @@ public sealed class CalendarStoreFacadeTests : IDisposable
 	[Fact]
 	public async Task GetCalendars_DelegatesCallToImplementation()
 	{
-		var expectedCalendar = new Calendar("cal1", "Work", Colors.Blue, false);
+		var expectedCalendar = new Calendar("cal1", "", "Work", Colors.Blue, false);
 
 		var mock = new MockCalendarStore
 		{

--- a/tests/Plugin.Maui.CalendarStore.Tests/DateFilterTests.cs
+++ b/tests/Plugin.Maui.CalendarStore.Tests/DateFilterTests.cs
@@ -61,4 +61,72 @@ public class DateFilterTests
 		// Assert
 		Assert.Equal(expectedMillis, actual);
 	}
+
+	[Fact]
+	public void BuildInstancesSelection_AlwaysExcludesDeleted()
+	{
+		var result = CalendarStore.BuildInstancesSelection("deleted", "calendar_id");
+
+		Assert.Equal("deleted != 1", result);
+	}
+
+	[Fact]
+	public void BuildInstancesSelection_WithCalendarId_AppendsFilter()
+	{
+		var result = CalendarStore.BuildInstancesSelection("deleted", "calendar_id", "42");
+
+		Assert.Equal("deleted != 1 AND calendar_id = 42", result);
+	}
+
+	[Fact]
+	public void BuildInstancesSelection_WithNullCalendarId_ExcludesDeletedOnly()
+	{
+		var result = CalendarStore.BuildInstancesSelection("deleted", "calendar_id", null);
+
+		Assert.Equal("deleted != 1", result);
+	}
+
+	[Fact]
+	public void BuildInstancesSelection_WithEmptyCalendarId_ExcludesDeletedOnly()
+	{
+		var result = CalendarStore.BuildInstancesSelection("deleted", "calendar_id", "");
+
+		Assert.Equal("deleted != 1", result);
+	}
+
+	[Fact]
+	public void GetOrAdd_ReturnsCachedValue_OnSecondCall()
+	{
+		var cache = new Dictionary<string, List<string>>();
+		int factoryCalls = 0;
+
+		var first = CalendarStore.GetOrAdd(cache, "key1", _ =>
+		{
+			factoryCalls++;
+			return new List<string> { "a", "b" };
+		});
+
+		var second = CalendarStore.GetOrAdd(cache, "key1", _ =>
+		{
+			factoryCalls++;
+			return new List<string> { "should not be called" };
+		});
+
+		Assert.Equal(1, factoryCalls);
+		Assert.Same(first, second);
+		Assert.Equal(new[] { "a", "b" }, first);
+	}
+
+	[Fact]
+	public void GetOrAdd_CallsFactory_ForDifferentKeys()
+	{
+		var cache = new Dictionary<string, int>();
+
+		var val1 = CalendarStore.GetOrAdd(cache, "a", _ => 1);
+		var val2 = CalendarStore.GetOrAdd(cache, "b", _ => 2);
+
+		Assert.Equal(1, val1);
+		Assert.Equal(2, val2);
+		Assert.Equal(2, cache.Count);
+	}
 }

--- a/tests/Plugin.Maui.CalendarStore.Tests/DateFilterTests.cs
+++ b/tests/Plugin.Maui.CalendarStore.Tests/DateFilterTests.cs
@@ -26,10 +26,9 @@ public class DateFilterTests
 		var expectedUtcMillis = date.ToUnixTimeMilliseconds();
 
 		// Act
-		var actual = CalendarStore.ToFilterTimestampMillis(date, date.Offset);
+		var actual = CalendarStore.ToFilterTimestampMillis(date);
 
-		// Assert — this FAILS with the current implementation because
-		// it adds the offset a second time, shifting the result.
+		// Assert
 		Assert.Equal(expectedUtcMillis, actual);
 	}
 
@@ -42,11 +41,10 @@ public class DateFilterTests
 
 		var expectedEndUtcMillis = endDate.ToUnixTimeMilliseconds();
 
-		// Act — current code passes startDate.Offset for the endDate too
-		var actual = CalendarStore.ToFilterTimestampMillis(endDate, startDate.Offset);
+		// Act — previously the bug was that startDate.Offset was applied to endDate
+		var actual = CalendarStore.ToFilterTimestampMillis(endDate);
 
-		// Assert — this FAILS because the startDate's offset (-5h) is applied
-		// to endDate instead of endDate's own offset (-4h), shifting it by 1 hour.
+		// Assert
 		Assert.Equal(expectedEndUtcMillis, actual);
 	}
 
@@ -58,9 +56,9 @@ public class DateFilterTests
 		var expectedMillis = date.ToUnixTimeMilliseconds();
 
 		// Act
-		var actual = CalendarStore.ToFilterTimestampMillis(date, date.Offset);
+		var actual = CalendarStore.ToFilterTimestampMillis(date);
 
-		// Assert — this passes even with the bug since offset is 0
+		// Assert
 		Assert.Equal(expectedMillis, actual);
 	}
 }

--- a/tests/Plugin.Maui.CalendarStore.Tests/DateFilterTests.cs
+++ b/tests/Plugin.Maui.CalendarStore.Tests/DateFilterTests.cs
@@ -1,0 +1,66 @@
+using Plugin.Maui.CalendarStore;
+
+namespace Plugin.Maui.CalendarStore.Tests;
+
+/// <summary>
+/// Tests for Android date range filter timestamp computation.
+/// Validates that UTC timestamps are computed correctly for calendar queries.
+/// See issue #51: stale event data caused partly by timezone double-counting.
+/// </summary>
+public class DateFilterTests
+{
+	[Theory]
+	[InlineData(5)]
+	[InlineData(-5)]
+	[InlineData(0)]
+	[InlineData(5.5)]  // India (UTC+5:30)
+	[InlineData(-9.5)] // Marquesas Islands
+	public void ToFilterTimestampMillis_ShouldNotShiftByTimezoneOffset(double offsetHours)
+	{
+		// Arrange: a date in a non-UTC timezone
+		var offset = TimeSpan.FromHours(offsetHours);
+		var date = new DateTimeOffset(2025, 1, 15, 10, 0, 0, offset);
+
+		// The correct UTC millis — DateTimeOffset.ToUnixTimeMilliseconds() is
+		// already timezone-independent, so the filter value should equal it exactly.
+		var expectedUtcMillis = date.ToUnixTimeMilliseconds();
+
+		// Act
+		var actual = CalendarStore.ToFilterTimestampMillis(date, date.Offset);
+
+		// Assert — this FAILS with the current implementation because
+		// it adds the offset a second time, shifting the result.
+		Assert.Equal(expectedUtcMillis, actual);
+	}
+
+	[Fact]
+	public void ToFilterTimestampMillis_EndDate_ShouldUseOwnOffset_NotStartDateOffset()
+	{
+		// Arrange: start and end dates with different offsets (e.g. DST transition)
+		var startDate = new DateTimeOffset(2025, 3, 8, 23, 0, 0, TimeSpan.FromHours(-5)); // EST
+		var endDate = new DateTimeOffset(2025, 3, 10, 10, 0, 0, TimeSpan.FromHours(-4));  // EDT
+
+		var expectedEndUtcMillis = endDate.ToUnixTimeMilliseconds();
+
+		// Act — current code passes startDate.Offset for the endDate too
+		var actual = CalendarStore.ToFilterTimestampMillis(endDate, startDate.Offset);
+
+		// Assert — this FAILS because the startDate's offset (-5h) is applied
+		// to endDate instead of endDate's own offset (-4h), shifting it by 1 hour.
+		Assert.Equal(expectedEndUtcMillis, actual);
+	}
+
+	[Fact]
+	public void ToFilterTimestampMillis_UtcDate_ShouldReturnSameValue()
+	{
+		// Arrange: a UTC date (offset = 0) should pass through unchanged
+		var date = new DateTimeOffset(2025, 6, 15, 12, 0, 0, TimeSpan.Zero);
+		var expectedMillis = date.ToUnixTimeMilliseconds();
+
+		// Act
+		var actual = CalendarStore.ToFilterTimestampMillis(date, date.Offset);
+
+		// Assert — this passes even with the bug since offset is 0
+		Assert.Equal(expectedMillis, actual);
+	}
+}

--- a/tests/Plugin.Maui.CalendarStore.Tests/MockCalendarStore.cs
+++ b/tests/Plugin.Maui.CalendarStore.Tests/MockCalendarStore.cs
@@ -1,0 +1,43 @@
+using Plugin.Maui.CalendarStore;
+
+namespace Plugin.Maui.CalendarStore.Tests;
+
+/// <summary>
+/// Mock implementation of <see cref="ICalendarStore"/> for testing the
+/// static <see cref="CalendarStore"/> facade.
+/// </summary>
+internal class MockCalendarStore : ICalendarStore
+{
+	public Func<Task<IEnumerable<Calendar>>>? OnGetCalendars { get; set; }
+	public Func<string, Task<Calendar>>? OnGetCalendar { get; set; }
+	public Func<string?, DateTimeOffset?, DateTimeOffset?, Task<IEnumerable<CalendarEvent>>>? OnGetEvents { get; set; }
+	public Func<string, Task<CalendarEvent>>? OnGetEvent { get; set; }
+
+	public Task<IEnumerable<Calendar>> GetCalendars() =>
+		OnGetCalendars?.Invoke() ?? Task.FromResult<IEnumerable<Calendar>>(Array.Empty<Calendar>());
+
+	public Task<Calendar> GetCalendar(string calendarId) =>
+		OnGetCalendar?.Invoke(calendarId) ?? throw new NotImplementedException();
+
+	public Task<IEnumerable<CalendarEvent>> GetEvents(string? calendarId = null,
+		DateTimeOffset? startDate = null, DateTimeOffset? endDate = null) =>
+		OnGetEvents?.Invoke(calendarId, startDate, endDate) ?? Task.FromResult<IEnumerable<CalendarEvent>>(Array.Empty<CalendarEvent>());
+
+	public Task<CalendarEvent> GetEvent(string eventId) =>
+		OnGetEvent?.Invoke(eventId) ?? throw new NotImplementedException();
+
+	public Task<string> CreateCalendar(string name, Color? color = null) => Task.FromResult("mock-cal-id");
+	public Task UpdateCalendar(string calendarId, string newName, Color? newColor = null) => Task.CompletedTask;
+	public Task DeleteCalendar(string calendarId) => Task.CompletedTask;
+	public Task DeleteCalendar(Calendar calendarToDelete) => Task.CompletedTask;
+	public Task<string> CreateEvent(string calendarId, string title, string description, string location,
+		DateTimeOffset startDateTime, DateTimeOffset endDateTime, bool isAllDay = false, Reminder[]? reminders = null) => Task.FromResult("mock-event-id");
+	public Task<string> CreateEvent(CalendarEvent calendarEvent) => Task.FromResult("mock-event-id");
+	public Task<string> CreateAllDayEvent(string calendarId, string title, string description,
+		string location, DateTimeOffset startDate, DateTimeOffset endDate) => Task.FromResult("mock-event-id");
+	public Task UpdateEvent(string eventId, string title, string description,
+		string location, DateTimeOffset startDateTime, DateTimeOffset endDateTime, bool isAllDay, Reminder[]? reminders = null) => Task.CompletedTask;
+	public Task UpdateEvent(CalendarEvent eventToUpdate) => Task.CompletedTask;
+	public Task DeleteEvent(string eventId) => Task.CompletedTask;
+	public Task DeleteEvent(CalendarEvent eventToDelete) => Task.CompletedTask;
+}

--- a/tests/Plugin.Maui.CalendarStore.Tests/Plugin.Maui.CalendarStore.Tests.csproj
+++ b/tests/Plugin.Maui.CalendarStore.Tests/Plugin.Maui.CalendarStore.Tests.csproj
@@ -1,0 +1,25 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Plugin.Maui.CalendarStore\Plugin.Maui.CalendarStore.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Reapplies the stale event data fix that was in #77 (reverted from v4.1.0 release).

**Fixes:**
- **iOS**: Call EventStore.Reset() before all read operations to clear cached data
- **Android**: Switch GetEvents from Events table to Instances table for accurate date-range queries; fix timezone double-counting in date filters

**Tests:**
- New xUnit test project with 12 tests (facade delegation + date filter TDD tests)

Fixes #51