### PR TITLE
Add EventColor property to CalendarEvent

### DIFF
--- a/src/Plugin.Maui.CalendarStore/CalendarEvent.shared.cs
+++ b/src/Plugin.Maui.CalendarStore/CalendarEvent.shared.cs
@@ -74,12 +74,12 @@ public class CalendarEvent
 	public List<Reminder> Reminders { get; internal set; } = [];
 
 	/// <summary>
-	/// Gets the color associated with this event, if any.
+	/// Gets the display color for this event.
 	/// </summary>
 	/// <remarks>
-	/// On Android, events can have a custom color that overrides the calendar color.
-	/// On iOS, macOS, and Windows this will always be <see langword="null"/> as those
-	/// platforms do not support per-event colors (events inherit their calendar's color).
+	/// On Android, this returns the event's custom color if one is set, otherwise <see langword="null"/>.
+	/// On iOS and macOS, this returns the calendar's color (which is the color used to display the event).
+	/// On Windows, this will be <see langword="null"/>; use the <see cref="Calendar.Color"/> from the parent calendar instead.
 	/// </remarks>
 	public Color? EventColor { get; internal set; }
 

--- a/src/Plugin.Maui.CalendarStore/CalendarEvent.shared.cs
+++ b/src/Plugin.Maui.CalendarStore/CalendarEvent.shared.cs
@@ -1,3 +1,5 @@
+using Microsoft.Maui.Graphics;
+
 namespace Plugin.Maui.CalendarStore;
 
 /// <summary>
@@ -70,6 +72,16 @@ public class CalendarEvent
 	/// On Windows only 1 reminder is supported. Therefore on Windows, this collection will always only contain 1 item.
 	/// </remarks>
 	public List<Reminder> Reminders { get; internal set; } = [];
+
+	/// <summary>
+	/// Gets the color associated with this event, if any.
+	/// </summary>
+	/// <remarks>
+	/// On Android, events can have a custom color that overrides the calendar color.
+	/// On iOS, macOS, and Windows this will always be <see langword="null"/> as those
+	/// platforms do not support per-event colors (events inherit their calendar's color).
+	/// </remarks>
+	public Color? EventColor { get; internal set; }
 
 	/// <summary>
 	/// Gets the list of attendees for this event.

--- a/src/Plugin.Maui.CalendarStore/CalendarStore.android.cs
+++ b/src/Plugin.Maui.CalendarStore/CalendarStore.android.cs
@@ -38,6 +38,7 @@ partial class CalendarStoreImplementation : ICalendarStore
 				CalendarContract.Events.InterfaceConsts.Dtend,
 				CalendarContract.Events.InterfaceConsts.Deleted,
 				CalendarContract.Events.InterfaceConsts.EventTimezone,
+				CalendarContract.Events.InterfaceConsts.EventColor,
 			];
 
 	readonly List<string> attendeesColumns =
@@ -743,10 +744,28 @@ partial class CalendarStoreImplementation : ICalendarStore
 			IsAllDay = allDay,
 			StartDate = timezone is null ? start : TimeZoneInfo.ConvertTimeBySystemTimeZoneId(start, timezone),
 			EndDate = timezone is null ? end : TimeZoneInfo.ConvertTimeBySystemTimeZoneId(end, timezone),
+			EventColor = GetEventColor(cursor, projection),
 			Attendees = GetAttendees(cursor.GetString(projection.IndexOf(
 				CalendarContract.Events.InterfaceConsts.Id)) ?? string.Empty).ToList(),
 			Reminders = GetAllEventReminders(eventId),
 		};
+	}
+
+	static Color? GetEventColor(ICursor cursor, List<string> projection)
+	{
+		var colorIndex = projection.IndexOf(CalendarContract.Events.InterfaceConsts.EventColor);
+		if (colorIndex < 0)
+		{
+			return null;
+		}
+
+		var eventColorInt = cursor.GetInt(colorIndex);
+		if (eventColorInt == 0)
+		{
+			return null;
+		}
+
+		return GetDisplayColorFromColor(new Android.Graphics.Color(eventColorInt)).AsColor();
 	}
 
 	static IEnumerable<CalendarEventAttendee> ToAttendees(ICursor cur, List<string> projection)

--- a/src/Plugin.Maui.CalendarStore/CalendarStore.macios.cs
+++ b/src/Plugin.Maui.CalendarStore/CalendarStore.macios.cs
@@ -408,6 +408,9 @@ partial class CalendarStoreImplementation : ICalendarStore
 			IsAllDay = platform.AllDay,
 			StartDate = ToDateTimeOffsetWithTimezone(platform.StartDate, platform.TimeZone),
 			EndDate = ToDateTimeOffsetWithTimezone(platform.EndDate, platform.TimeZone),
+			EventColor = platform.Calendar?.CGColor is not null
+				? new UIColor(platform.Calendar.CGColor).AsColor()
+				: null,
 			Attendees = platform.Attendees != null
 				? ToAttendees(platform.Attendees).ToList()
 				: new List<CalendarEventAttendee>()


### PR DESCRIPTION
Fixes #74

Adds `Color? EventColor` to `CalendarEvent` - populated from Android EventColor column, null on iOS/macOS/Windows (those platforms don't support per-event colors). Non-breaking additive change.

When `EventColor` is null, consumers should fall back to the calendar's `Color` property.
