### PR TITLE
Fix iOS calendar permission status mapping

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,3 +26,14 @@ jobs:
 
     - name: Build
       run: dotnet build src/Plugin.Maui.CalendarStore/Plugin.Maui.CalendarStore.csproj -c Release
+
+    - name: Pack pull request artifact
+      if: github.event_name == 'pull_request'
+      run: dotnet pack src/Plugin.Maui.CalendarStore/Plugin.Maui.CalendarStore.csproj -c Release --no-build -o artifacts -p:PackageVersion=5.0.1-pr.${{ github.event.pull_request.number }}.${{ github.run_number }}
+
+    - name: Upload pull request artifact
+      if: github.event_name == 'pull_request'
+      uses: actions/upload-artifact@v4
+      with:
+        name: nuget
+        path: artifacts/*.nupkg

--- a/src/Plugin.Maui.CalendarStore/CalendarPermissions.ios.cs
+++ b/src/Plugin.Maui.CalendarStore/CalendarPermissions.ios.cs
@@ -13,7 +13,7 @@ public class WriteOnlyCalendar : Permissions.BasePlatformPermission
 	{
 		EnsureDeclared();
 
-		return Task.FromResult(EventPermission.CheckPermissionStatus(EKEntityType.Event));
+		return Task.FromResult(EventPermission.CheckWritePermissionStatus(EKEntityType.Event));
 	}
 
 	/// <inheritdoc/>
@@ -22,7 +22,7 @@ public class WriteOnlyCalendar : Permissions.BasePlatformPermission
 	{
 		EnsureDeclared();
 
-		var status = EventPermission.CheckPermissionStatus(EKEntityType.Event);
+		var status = EventPermission.CheckWritePermissionStatus(EKEntityType.Event);
 		if (status == PermissionStatus.Granted)
 		{
 			return status;
@@ -56,7 +56,7 @@ public class FullAccessCalendar : Permissions.BasePlatformPermission
 	{
 		EnsureDeclared();
 
-		return Task.FromResult(EventPermission.CheckPermissionStatus(EKEntityType.Event));
+		return Task.FromResult(EventPermission.CheckFullAccessPermissionStatus(EKEntityType.Event));
 	}
 
 	/// <inheritdoc/>
@@ -64,7 +64,7 @@ public class FullAccessCalendar : Permissions.BasePlatformPermission
 	{
 		EnsureDeclared();
 
-		var status = EventPermission.CheckPermissionStatus(EKEntityType.Event);
+		var status = EventPermission.CheckFullAccessPermissionStatus(EKEntityType.Event);
 		if (status == PermissionStatus.Granted)
 		{
 			return status;
@@ -97,7 +97,7 @@ public class RemindersCalendar : Permissions.BasePlatformPermission
 	{
 		EnsureDeclared();
 
-		var status = EventPermission.CheckPermissionStatus(EKEntityType.Event);
+		var status = EventPermission.CheckFullAccessPermissionStatus(EKEntityType.Event);
 		if (status == PermissionStatus.Granted)
 		{
 			return status;
@@ -123,11 +123,23 @@ public class RemindersCalendar : Permissions.BasePlatformPermission
 
 static class EventPermission
 {
-	internal static PermissionStatus CheckPermissionStatus(EKEntityType entityType)
+	internal static PermissionStatus CheckFullAccessPermissionStatus(EKEntityType entityType)
+	{
+		return CheckPermissionStatus(entityType, allowWriteOnly: false);
+	}
+
+	internal static PermissionStatus CheckWritePermissionStatus(EKEntityType entityType)
+	{
+		return CheckPermissionStatus(entityType, allowWriteOnly: true);
+	}
+
+	static PermissionStatus CheckPermissionStatus(EKEntityType entityType, bool allowWriteOnly)
 	{
 		var status = EKEventStore.GetAuthorizationStatus(entityType);
 		return status switch
 		{
+			EKAuthorizationStatus.WriteOnly when allowWriteOnly => PermissionStatus.Granted,
+			// Apple's FullAccess status is bound as Authorized because both use the value 3.
 			EKAuthorizationStatus.Authorized => PermissionStatus.Granted,
 			EKAuthorizationStatus.Denied => PermissionStatus.Denied,
 			EKAuthorizationStatus.Restricted => PermissionStatus.Restricted,


### PR DESCRIPTION
## Description

Fixes #87 by separating EventKit full-access checks from write-capable checks on iOS 17+.

The investigation found one important .NET binding detail: Apple’s `EKAuthorizationStatusFullAccess` and the .NET `EKAuthorizationStatus.Authorized` member share raw value `3`, so full access is already represented by `Authorized` in the target framework. `EKAuthorizationStatus.WriteOnly` is the distinct state that was previously falling through to `PermissionStatus.Unknown`.

Write-only permission checks now accept both `WriteOnly` and `Authorized` (full access), while full-access checks continue to reject `WriteOnly` and accept `Authorized`. This prevents a stronger full-access grant from being rejected by write operations without allowing write-only grants to pass read/full-access checks.

The plugin CI workflow now also uploads a `nuget` artifact for pull requests. Download the artifact from the completed **Build for CI** workflow run and install the included prerelease `.nupkg` to test this fix on a physical iOS 17+ device.

## Platforms Affected

- [ ] Android
- [x] iOS
- [x] macOS (Catalyst)
- [ ] Windows

## Changes

### API Changes
None.

### Breaking Changes
None.

## Checklist

- [x] Plugin builds successfully (`dotnet build src/Plugin.Maui.CalendarStore/Plugin.Maui.CalendarStore.csproj -c Release`)
- [x] Sample app builds successfully (`dotnet build samples/Plugin.Maui.CalendarStore.Sample/Plugin.Maui.CalendarStore.Sample.csproj -c Release`)
- [x] All new public APIs have XML documentation comments (not applicable; no public API changes)
- [x] Platform implementations added/updated for all supported platforms (iOS/Mac Catalyst only)
- [x] Generic .NET stub updated (not applicable; no API surface added)
- [x] Sample app updated to demonstrate changes (not applicable; behavior fix only)
- [x] README.md updated (not applicable; no public API change)

Tests: 18 passed.